### PR TITLE
Add new `value` module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        tc: ["1.91", "stable", "beta", "nightly"]
+        tc: ["1.95", "stable", "beta", "nightly"]
         include:
         - tc: stable
         - tc: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
     "/examples/*",
     "/src/*",
 ]
-rust-version = "1.91"
+rust-version = "1.95"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -38,6 +38,7 @@ default-features = false
 package = "as_repr-core"
 version = "1.7.0"
 default-features = false
+features = ["cmp", "num"]
 
 [dependencies.bitflags]
 version = "2.13.0"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check out the [documentation] for examples.
 
 ## MSRV
 
-The current MSRV is Rust 1.91.
+The current MSRV is Rust 1.95.
 
 Any future MSRV updates will follow the [Ardaku MSRV guidelines].
 

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,0 +1,1 @@
+//! Ranged floats

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,7 @@ pub mod bitwise;
 mod cmp;
 mod convert;
 mod error;
+pub mod float;
 mod format;
 mod from_repr;
 mod impl_ascii;
@@ -315,9 +316,11 @@ mod random;
 pub mod range;
 mod shl;
 mod shr;
+pub mod time;
 pub mod types;
 mod unchecked;
 pub mod unit;
+pub mod value;
 
 pub use self::{
     error::{Error, Result},

--- a/src/num/ranged.rs
+++ b/src/num/ranged.rs
@@ -40,7 +40,7 @@ where
     R: MultiRange<T::ZeroablePrimitive>,
 {
     fn clone(&self) -> Self {
-        Ranged::from_unchecked(self.0)
+        *self
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,1 @@
+//! Ranged temporal types

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,10 +10,19 @@ use core::{marker::PhantomData, range::RangeInclusive, time::Duration};
 
 use as_repr::{cmp::Cmp, num::Number};
 
+macro_rules! impl_value_for_numbers {
+    ($($number:ty),* $(,)?) => {
+        $(
+            impl Value for $number {
+                const MAX: Self = <Self as Number>::REPR_MAX;
+                const MIN: Self = <Self as Number>::REPR_MIN;
+            }
+        )*
+    };
+}
+
 /// A type with an minimum and maximum value
-pub trait Value:
-    Sized + Copy + PartialOrd + Cmp + val::Sealed + 'static
-{
+pub trait Value: Sized + Copy + PartialOrd + Cmp + 'static {
     /// The smallest value that can be represented by this type
     const MIN: Self;
     /// The largest value that can be represented by this type
@@ -25,12 +34,8 @@ impl Value for Duration {
     const MIN: Self = Duration::ZERO;
 }
 
-impl<T> Value for T
-where
-    T: Sized + Copy + PartialOrd + Cmp + num::Num + 'static,
-{
-    const MAX: Self = <Self as Number>::REPR_MAX;
-    const MIN: Self = <Self as Number>::REPR_MIN;
+impl_value_for_numbers! {
+    f32, f64, i8, i16, i32, i64, i128, u8, u16, u32, u64, u128,
 }
 
 /// A value that cannot be constructed
@@ -103,33 +108,4 @@ mod sets {
         /// The number of contiguous sets
         const COUNT: usize;
     }
-}
-
-mod num {
-    use super::*;
-
-    /// A numeric type
-    pub trait Num: Number<ToRepr = Self> {}
-
-    impl Num for f32 {}
-    impl Num for f64 {}
-    impl Num for i8 {}
-    impl Num for i16 {}
-    impl Num for i32 {}
-    impl Num for i64 {}
-    impl Num for i128 {}
-    impl Num for u8 {}
-    impl Num for u16 {}
-    impl Num for u32 {}
-    impl Num for u64 {}
-    impl Num for u128 {}
-}
-
-mod val {
-    use super::*;
-
-    pub trait Sealed {}
-
-    impl Sealed for Duration {}
-    impl<T> Sealed for T where T: num::Num {}
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,135 @@
+//! Traits for working with different kinds of values
+//!
+//! Ranch defines a [`Value`] as a type with a minimum and a maximum.  As of
+//! right now this includes two classes:
+//!
+//!  - Numbers (ints and floats)
+//!  - [`Duration`]s
+
+use core::{marker::PhantomData, range::RangeInclusive, time::Duration};
+
+use as_repr::{cmp::Cmp, num::Number};
+
+/// A type with an minimum and maximum value
+pub trait Value:
+    Sized + Copy + PartialOrd + Cmp + val::Sealed + 'static
+{
+    /// The smallest value that can be represented by this type
+    const MIN: Self;
+    /// The largest value that can be represented by this type
+    const MAX: Self;
+}
+
+impl Value for Duration {
+    const MAX: Self = Duration::MAX;
+    const MIN: Self = Duration::ZERO;
+}
+
+impl<T> Value for T
+where
+    T: Sized + Copy + PartialOrd + Cmp + num::Num + 'static,
+{
+    const MAX: Self = <Self as Number>::REPR_MAX;
+    const MIN: Self = <Self as Number>::REPR_MIN;
+}
+
+/// A value that cannot be constructed
+pub trait Uninhabited<T> {}
+
+impl<T, V> Uninhabited<T> for V
+where
+    V: Validate<T, ContiguousSets = sets::Sets<0>>,
+    T: Value,
+{
+}
+
+/// A type with a contiguous set of valid values
+pub trait Contiguous<T> {}
+
+impl<T, V> Contiguous<T> for V
+where
+    V: Validate<T, ContiguousSets = sets::Sets<1>>,
+    T: Value,
+{
+}
+
+/// A type with a list of valid inclusive ranges
+pub trait Validate<T>: Sized
+where
+    T: Value,
+{
+    /// The number of contiguous sets
+    type ContiguousSets: sets::ContiguousSets;
+
+    /// List of inclusive ranges that are valid
+    const VALID_FOR: &'static [RangeInclusive<T>];
+    /// Proof that the number of contiguous sets matches the number of valid
+    /// inclusive ranges
+    const PROOF: proof::Proof<Self, T>;
+}
+
+mod proof {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct Proof<T, V>(PhantomData<fn() -> (T, V)>);
+
+    impl<T, V> Proof<T, V>
+    where
+        T: Validate<V>,
+        V: Value,
+    {
+        pub const fn new() -> Self {
+            if <T::ContiguousSets as sets::ContiguousSets>::COUNT
+                != T::VALID_FOR.len()
+            {
+                panic!(
+                    "Length of VALID_FOR must match the number of contiguous sets"
+                );
+            }
+
+            Proof(PhantomData)
+        }
+    }
+}
+
+mod sets {
+    /// Number of contiguous sets
+    #[derive(Debug)]
+    pub struct Sets<const N: usize>;
+
+    /// A type that defines the number of contiguous sets
+    pub trait ContiguousSets {
+        /// The number of contiguous sets
+        const COUNT: usize;
+    }
+}
+
+mod num {
+    use super::*;
+
+    /// A numeric type
+    pub trait Num: Number<ToRepr = Self> {}
+
+    impl Num for f32 {}
+    impl Num for f64 {}
+    impl Num for i8 {}
+    impl Num for i16 {}
+    impl Num for i32 {}
+    impl Num for i64 {}
+    impl Num for i128 {}
+    impl Num for u8 {}
+    impl Num for u16 {}
+    impl Num for u32 {}
+    impl Num for u64 {}
+    impl Num for u128 {}
+}
+
+mod val {
+    use super::*;
+
+    pub trait Sealed {}
+
+    impl Sealed for Duration {}
+    impl<T> Sealed for T where T: num::Num {}
+}


### PR DESCRIPTION
Bumps MSRV to 1.95 since it's required for the new range types.

New traits:

 - `Value` (min and max)
 - `Validate` (range list)
 - `Contiguous` (single range)
 - `Uninhabited` (no valid ranges - implement for `!`/`Infallible` type)

Traits to replace:

 - `MultiRange` (min and max, range list)
 - `Range` (min and max, single range)

Adds:

 - `time` module
 - `float` module